### PR TITLE
Change exe and zip file name

### DIFF
--- a/windows/build-windows.ps1
+++ b/windows/build-windows.ps1
@@ -365,7 +365,7 @@ try {
     Copy-Item $VcredistExe $TempRedistDir
 
     # Build standalone installer.
-    $ZipInstaller = (Join-Path $InstallerDir "QtLinguist-Standalone-$Version.zip")
+    $ZipInstaller = (Join-Path $InstallerDir "QtLinguist-$Version-Standalone.zip")
     Get-ChildItem -Recurse $TempRootDir | New-ZipFile $ZipInstaller -Force -Root $TempDir
 }
 finally {

--- a/windows/qtlinguist.nsi
+++ b/windows/qtlinguist.nsi
@@ -40,7 +40,7 @@ Name "Qt Linguist"
 !verbose pop
 
 ; Installer file name.
-OutFile "${RootDir}\installers\QtLinguist-${ProductVersion}.exe"
+OutFile "${RootDir}\installers\QtLinguist-${ProductVersion}-Installer.exe"
 
 ; Registry entry for product info and uninstallation info.
 !define ProductKey "Software\QtLinguist"


### PR DESCRIPTION
Change exe and zip file name created by script

Then the file name should be 

QTLinguist-x.x.x-Installer.exe
QTLinguist-x.x.x-Standalone-zip

then it's more clear and ordered.

Thanks.
