### PR TITLE
Remove assumptions about Qt installation for Mac

### DIFF
--- a/mac/build-mac.sh
+++ b/mac/build-mac.sh
@@ -42,7 +42,8 @@ DMGSIZE=64m
 QTDIR=${1:-$QTDIR}
 [[ -z "$QTDIR" ]] && error "Path to Qt installation must be given as parameter or via environment variable QTDIR"
 QTBINDIR="$QTDIR/bin"
-[[ ! -f "$QTBINDIR/qmake" ]] && error "Could not find qmake in $QTBINDIR"
+QMAKE="$QTBINDIR/qmake"
+[[ -x "$QMAKE" ]] || error "qmake not found in $QTBINDIR"
 
 # Various directories.
 SCRIPTDIR=$(cd $(dirname $BASH_SOURCE); pwd)
@@ -54,7 +55,7 @@ LINGDIR="$QTBINDIR/Linguist.app"
 [[ -x "$LINGDIR/Contents/MacOS/Linguist" ]] || error "Linguist not found in $LINGDIR"
 
 # Get Qt version from qmake.
-VERSION=$("$QTBINDIR/qmake" --version | grep -o '[Qq]t [Vv]ersion [0-9][0-9\.-]*' | sed -e 's/^[Qq]t [Vv]ersion //')
+VERSION=$("$QMAKE" --version | grep -o '[Qq]t [Vv]ersion [0-9][0-9\.-]*' | sed -e 's/^[Qq]t [Vv]ersion //')
 [[ -z "$VERSION" ]] && error "Could not determine Qt version"
 
 echo "Using Qt $VERSION from $QTDIR"

--- a/mac/build-mac.sh
+++ b/mac/build-mac.sh
@@ -113,6 +113,7 @@ SetFile -a C "$VOLROOT"
 # Format the appearance of the DMG in Finder when opened.
 mkdir -p "$VOLROOT/.background"
 cp $ROOTDIR/images/dmg-background.png "$VOLROOT/.background/background.png"
+rm -rf "$VOLROOT/.fseventsd" "$VOLROOT/.DS_store"
 echo '
    tell application "Finder"
      tell disk "'${VOLUME}'"
@@ -125,6 +126,7 @@ echo '
            set arrangement of theViewOptions to not arranged
            set icon size of theViewOptions to 128
            set background picture of theViewOptions to file ".background:background.png"
+           set position of item ".background" of container window to {1000, 1000}
            set position of item "Qt Linguist" of container window to {100, 100}
            set position of item "Applications" of container window to {375, 100}
            update without registering applications


### PR DESCRIPTION
The `build-mac.sh` script has some assumptions about where and how Qt is installed.

This PR removes those assumptions in favor of letting the user hand over the Qt installation path via a command line parameter or environment variable `QTDIR`.
This also solves the issue that an older Qt version could be used in case multiple versions are installed (sorting is broken if you have, for example, 5.9.6 and 5.12.3 installed).

Additionally, the Qt version is now determined by calling `qmake --version` instead of assuming that the Qt version is part of the installation path.

And I also had the issue that the hidden folders in the DMG were visible.
So this PR also removes the directories `.DS_store` and `.fseventsd` in the DMG if they exist and moves the `.background` directory out of sight.