### PR TITLE
Changes to build structure

### DIFF
--- a/windows/build--windows.bat
+++ b/windows/build--windows.bat
@@ -1,0 +1,16 @@
+@echo off
+
+cls
+powershell .\build-windows.ps1 -NoPause
+echo.
+echo **** Installers and portable archive created
+echo.
+dir ..\installers
+
+
+echo.
+echo.
+echo    #### Press any key to exit #####
+pause >NUL
+echo.
+echo.

--- a/windows/build-windows.ps1
+++ b/windows/build-windows.ps1
@@ -328,6 +328,7 @@ if ($VcredistDir) {
     }
     elseif ($exe.Count -gt 1) {
         Write-Output "More that one .exe in $VcredistDir"
+        $VCRedistrError="S"
     }
     else {
         Write-Output "No VC++ Redistributable found"
@@ -371,6 +372,7 @@ try {
     Copy-Item (Join-Path $TranslationsDir "qtmultimedia_*.qm") $TempTransDir
     Copy-Item (Join-Path $TranslationsDir "qtxmlpatterns_*.qm") $TempTransDir
 
+ $InstallerFileName="QtLinguist-$Version"
     # Build the installer.
     & $NsisExe `
         "/DProductVersion=$Version" `
@@ -378,15 +380,17 @@ try {
         "/DBinDir=$TempBinDir" `
         "/DVcredistExe=$VcredistExe" `
         "/DVcredistName=$VcredistName" `
+        "/DExeFileName=$InstallerFileName" `
         "$($NsisScript)"
 
     # Copy VC++ redistributable libraries.
     $TempRedistDir = (Join-Path $TempRootDir "vcredist")
     [void] (New-Item -ItemType Directory -Force $TempRedistDir)
-    Copy-Item $VcredistExe $TempRedistDir
-
+    if (!$TempRedistDir) {
+       Copy-Item $VcredistExe $TempRedistDir
+    }
     # Build standalone installer.
-    $ZipInstaller = (Join-Path $InstallerDir "QtLinguist-Standalone-$Version.zip")
+    $ZipInstaller = (Join-Path $InstallerDir "$InstallerFileName.zip")
     Get-ChildItem -Recurse $TempRootDir | New-ZipFile $ZipInstaller -Force -Root $TempDir
 }
 finally {

--- a/windows/qtlinguist.nsi
+++ b/windows/qtlinguist.nsi
@@ -40,7 +40,8 @@ Name "Qt Linguist"
 !verbose pop
 
 ; Installer file name.
-OutFile "${RootDir}\installers\QtLinguist-${ProductVersion}.exe"
+OutFile "${RootDir}\installers\${ExeFileName}.exe"
+
 
 ; Registry entry for product info and uninstallation info.
 !define ProductKey "Software\QtLinguist"


### PR DESCRIPTION
Add DOS batch files to run PowerShell script.

Change Powershell script 

- to avoid missng zip creation fi more than one Vc redistruibitable file are availbel (now are present x86 and x64 version in vc redistr folder)
- Set file name for exe/zip file as QTLinguist-Version.exe/zip
- Set filename variable to pass to .NSI script with Output zip file name.

Change NSIS script to get ZIP file name passed by PowerShell script.
  
Thanks.